### PR TITLE
Forward

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,4 @@ vignettes/*.tex
 
 dev/
 R/fold_stability.R
-gosset.Rproj
+

--- a/.gitignore
+++ b/.gitignore
@@ -36,5 +36,3 @@ vignettes/*.tex
 .Rproj.user
 
 dev/
-R/fold_stability.R
-

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ vignettes/*.tex
 
 dev/
 R/fold_stability.R
+gosset.Rproj

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: gosset
 Type: Package
 Title: Modelling Metadata and Crowdsourced Citizen Science
-Version: 0.2.6.96
+Version: 0.2.6.97
 Authors@R: c(person("Kauê", "de Sousa", 
         email = "kaue.desousa@inn.no", role = c("aut", "cre"),
         comment = c(ORCID = "0000-0002-7571-7845")),

--- a/R/forward.R
+++ b/R/forward.R
@@ -212,7 +212,7 @@ forward <- function(formula, data, k = NULL, folds = NULL,
                                      )
                   )
 
-    dimnames(models) <- list(seq_len(fs),
+    names(models) <- list(seq_len(fs),
                              paste0("bin", seq_len(k)),
                              opt.select)
 
@@ -314,7 +314,7 @@ forward <- function(formula, data, k = NULL, folds = NULL,
 
     # model calls to add into list of parameters
     call_m <- paste0(Y, " ~ ", paste(paste(var_keep, collapse = " "), exp_var))
-    call_m <- tibble::as_tibble(cbind(call = call_m, models_avg))
+    call_m <- as.data.frame(cbind(call = call_m, models_avg))
     call_m[2:ncol(call_m)] <- lapply(call_m[2:ncol(call_m)], as.numeric)
     call_m <- list(call_m, models)
 


### PR DESCRIPTION
Fix the following:
Error in dimnames(models) <- list(seq_len(fs), paste0("bin", seq_len(k)),  :
  length of 'dimnames' [3] not equal to array extent

The `x` argument of `as_tibble.matrix()` must have unique column names if `.name_repair` is omitted as of tibble 2.0.0.
Using compatibility `.name_repair`.